### PR TITLE
Adds yle-dl as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,4 @@ RUN rm yledl.tar
 RUN make install
 
 WORKDIR /out
+ENTRYPOINT /usr/local/bin/yle-dl


### PR DESCRIPTION
Makes image easier to use, eg.

```
$ docker run -it --rm taskinen/yle-dl URL
```

instead of `$ docker run -it --rm taskinen/yle-dl yle-dl URL`