### PR TITLE
Add wget (and other tweaks)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM alpine:3.7
 LABEL maintainer="Timo Taskinen <timo.taskinen@iki.fi>"
 
-ENV YLEDLVERSION 2.30
-
 RUN apk add --no-cache \
     bash \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN apk add --no-cache \
     php7-simplexml \
     py-pip \
     py-setuptools \
-    py-lxml
+    py-lxml \
+    wget
 
 RUN pip install -U pip setuptools youtube_dl yle-dl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,25 @@ ENV YLEDLVERSION 2.30
 RUN apk add --no-cache \
     bash \
     curl \
-    tar \
-    gcc \
-    musl-dev \
-    make \
-    python \
-    py-crypto \
-    python2-dev \
-    libxslt-dev \
-    libxml2-dev \
-    rtmpdump \
     ffmpeg \
+    gcc \
+    libxml2-dev \
+    libxslt-dev \
+    make \
+    musl-dev \
     php7 \
     php7-bcmath \
     php7-curl \
     php7-mcrypt \
     php7-simplexml \
+    py-crypto \
+    py-lxml \
     py-pip \
     py-setuptools \
-    py-lxml \
+    python \
+    python2-dev \
+    rtmpdump \
+    tar \
     wget
 
 RUN pip install -U pip setuptools youtube_dl yle-dl


### PR DESCRIPTION
This adds a _wget_ package to handle the issue described in #5.

Also while at it I couldn't resist adding a couple of other small tweaks:
- sorting the package list alphabetically makes it easier to manage
- I removed the environment variable line `ENV YLEDLVERSION 2.30` because it seemed to be not used anywhere. If there's a need to tag a specific version of _yle-dl_, I think a better way would be to do it with `pip install yle-dl==2.30`

Feel free to discard the other commits :)