### PR TITLE
Remove PHP, RTMPDump and youtube-dl dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,22 +10,16 @@ RUN apk add --no-cache \
     libxslt-dev \
     make \
     musl-dev \
-    php7 \
-    php7-bcmath \
-    php7-curl \
-    php7-mcrypt \
-    php7-simplexml \
     py3-crypto \
     py3-lxml \
     py3-pip \
     py3-setuptools \
     python3 \
     python3-dev \
-    rtmpdump \
     tar \
     wget
 
-RUN pip3 install -U pip setuptools youtube_dl yle-dl
+RUN pip3 install -U pip setuptools yle-dl
 
 WORKDIR /out
 ENTRYPOINT ["yle-dl"]


### PR DESCRIPTION
_PHP_, _RTMPDump_ and _youtube-dl_ backends have been removed from _yle-dl_.

See: 
- https://github.com/aajanki/yle-dl/commit/be13aebe950a832635072a6b88677d4199c1f22c
- https://github.com/aajanki/yle-dl/commit/dbd7270f5247fbcc141a3dddabc5a1c068f2b8f4
- https://github.com/aajanki/yle-dl/commit/73761a504779b62f82dab50c3f06870b981a0c01

The latest _yle-dl_ release in _pip_ has those backends removed already.